### PR TITLE
US-001-2 feat: POST /bots/{id}/area to set mining range (Closes #3)

### DIFF
--- a/docs/00_practice/ai_session/2025-08-16-1740-dev-session.md
+++ b/docs/00_practice/ai_session/2025-08-16-1740-dev-session.md
@@ -1,0 +1,41 @@
+# セッション記録: US-001-2 採掘エリア API 開発
+
+日付: 2025-08-16 08:38:36 UTC
+
+概要
+- US-001-2: POST /bots/{id}/area の実装
+- ブランチ作成: feat/3-setarea-api
+- bedrock-protocol を用いた Bot モデルのエリア管理追加
+- CLI コマンド: src/cli/setarea.ts の追加
+- ユニットテストの拡充: setMiningArea の成功/無効/未存在ケースを追加
+- ビルド・PR 作成済み: PR 13 番目
+- 設計参照: docs/03_design/api/openapi.yaml / docs/03_design/api/error_catalog.md
+- StateDB: インメモリ Map による保持（永続化は別Issue）
+
+実装内容の要点
+- API: POST /bots/{botId}/area 実装、成功時 202 Accepted を返却
+- ルーティング更新: src/index.ts
+- コントローラ更新: BotController に setMiningArea 実装
+  - Bot が存在しない場合 404 + B002
+  - 無効な範囲の場合 400 + B001
+- モデル/サービス拡張
+  - src/models/bot.model.ts に miningArea を保持
+  - src/services/bot.service.ts に setMiningArea(botId, area) 実装
+- CLI: setarea コマンドを追加、成功時は "Area set" を出力
+- テスト: tests/unit/bot.controller.test.ts に setMiningArea の挙動テストを追加
+
+テスト結果
+- lint: 警告のみ、エラーなし
+- npm test: 5 件すべて PASS
+
+ブランチ/プルリクエスト
+- ブランチ: feat/3-setarea-api
+- PR: https://github.com/u-keiya/Tsuruhashi/pull/13
+- Base ブランチは main 使用、クローズ済み Issue: US-001-2
+
+今後の作業候補
+- 永続化の追加（SQLite 等）を次のIssueで検討
+- CLI の厳密なバリデーション強化
+
+参照ファイル（セッション記録の格納元）
+- docs/00_practice/ai_session/2025-08-16-session.md:1

--- a/src/cli/setarea.ts
+++ b/src/cli/setarea.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import axios from 'axios';
+
+const API_BASE_URL = 'http://localhost:8080';
+
+type Coord = { x: number; y: number; z: number };
+type MiningArea = { start: Coord; end: Coord };
+
+async function setArea(botId: string, area: MiningArea): Promise<void> {
+  try {
+    const resp = await axios.post(`${API_BASE_URL}/bots/${botId}/area`, area, {
+      validateStatus: () => true
+    });
+
+    if (resp.status === 202) {
+      console.log('Area set');
+      return;
+    }
+
+    // エラーフォーマット { error: { code, message } } に対応
+    const code = (resp.data && resp.data.error && resp.data.error.code) || 'UNKNOWN';
+    const message =
+      (resp.data && resp.data.error && resp.data.error.message) ||
+      resp.statusText ||
+      'Failed';
+    console.error(`Failed to set area: ${code} ${message}`);
+    process.exit(1);
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      console.error('HTTP error:', e.response?.data || e.message);
+    } else {
+      console.error('Unexpected error:', e);
+    }
+    process.exit(1);
+  }
+}
+
+yargs(hideBin(process.argv))
+  .command(
+    'set',
+    'Set mining area for a bot',
+    (y) =>
+      y
+        .option('bot-id', { alias: 'b', type: 'string', demandOption: true, describe: 'Target bot ID' })
+        .option('start-x', { type: 'number', demandOption: true })
+        .option('start-y', { type: 'number', demandOption: true })
+        .option('start-z', { type: 'number', demandOption: true })
+        .option('end-x', { type: 'number', demandOption: true })
+        .option('end-y', { type: 'number', demandOption: true })
+        .option('end-z', { type: 'number', demandOption: true }),
+    async (argv) => {
+      const botId = argv['bot-id'] as string;
+
+      const area: MiningArea = {
+        start: {
+          x: Number(argv['start-x']),
+          y: Number(argv['start-y']),
+          z: Number(argv['start-z'])
+        },
+        end: {
+          x: Number(argv['end-x']),
+          y: Number(argv['end-y']),
+          z: Number(argv['end-z'])
+        }
+      };
+
+      await setArea(botId, area);
+    }
+  )
+  .demandCommand(1, 'You must specify a command')
+  .strict()
+  .help()
+  .parse();

--- a/src/controllers/bot.controller.ts
+++ b/src/controllers/bot.controller.ts
@@ -106,7 +106,7 @@ export default class BotController {
         res.status(400).json({ error: { code: 'B001', message: 'InvalidRange' } });
       } else {
         console.error('Error in setMiningArea:', error);
-        res.status(500).json({ error: 'Failed to set mining area' });
+        res.status(500).json({ error: { code: 'B000', message: 'Failed to set mining area' } });
       }
     }
   }

--- a/src/controllers/bot.controller.ts
+++ b/src/controllers/bot.controller.ts
@@ -84,6 +84,8 @@ export default class BotController {
   /**
    * 採掘範囲を設定する
    * POST /bots/:id/area
+   * リクエストボディは MiningArea（start/end がトップレベル）形式:
+   * { "start": { x, y, z }, "end": { x, y, z } }
    * - 正常: 202 Accepted
    * - 無効範囲: 400 + B001 InvalidRange
    * - Bot未存在: 404 + B002 BotNotFound
@@ -98,6 +100,7 @@ export default class BotController {
     }
 
     try {
+      // req.body は MiningArea 形式（area プロパティなし、start/end が直下）
       const area = req.body as MiningArea;
       this.botService.setMiningArea(id, area);
       res.status(202).send();

--- a/src/controllers/bot.controller.ts
+++ b/src/controllers/bot.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import BotService from '../services/bot.service';
-import { SummonBotRequest } from '../types/bot.types';
+import { SummonBotRequest, MiningArea } from '../types/bot.types';
 
 /**
  * Botのコントローラークラス
@@ -79,5 +79,35 @@ export default class BotController {
   getAllBots(_req: Request, res: Response): void {
     const bots = this.botService.getAllBots();
     res.status(200).json(bots);
+  }
+
+  /**
+   * 採掘範囲を設定する
+   * POST /bots/:id/area
+   * - 正常: 202 Accepted
+   * - 無効範囲: 400 + B001 InvalidRange
+   * - Bot未存在: 404 + B002 BotNotFound
+   */
+  setMiningArea(req: Request, res: Response): void {
+    const { id } = req.params;
+    const bot = this.botService.getBot(id);
+
+    if (!bot) {
+      res.status(404).json({ error: { code: 'B002', message: 'Bot not found' } });
+      return;
+    }
+
+    try {
+      const area = req.body as MiningArea;
+      this.botService.setMiningArea(id, area);
+      res.status(202).send();
+    } catch (error) {
+      if (error instanceof Error && error.message === 'InvalidRange') {
+        res.status(400).json({ error: { code: 'B001', message: 'InvalidRange' } });
+      } else {
+        console.error('Error in setMiningArea:', error);
+        res.status(500).json({ error: 'Failed to set mining area' });
+      }
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ app.post('/bots/summon', (req, res) => botController.summonBot(req, res));
 app.get('/bots/:id', (req, res) => botController.getBot(req, res));
 app.delete('/bots/:id', (req, res) => botController.deleteBot(req, res));
 app.get('/bots', (req, res) => botController.getAllBots(req, res));
+app.post('/bots/:id/area', (req, res) => botController.setMiningArea(req, res));
 
 // サーバーの起動
 app.listen(port, () => {

--- a/src/models/bot.model.ts
+++ b/src/models/bot.model.ts
@@ -96,18 +96,31 @@ export default class Bot {
     if (!Bot.isValidCoord(area?.start) || !Bot.isValidCoord(area?.end)) {
       throw new Error('InvalidRange');
     }
-    this.miningArea = area;
+    // 外部からの参照/改変を防ぐためディープコピーして保持
+    this.miningArea = {
+      start: { x: area.start.x, y: area.start.y, z: area.start.z },
+      end:   { x: area.end.x,   y: area.end.y,   z: area.end.z   }
+    };
   }
 
   /**
    * 採掘エリアの取得
    */
   getMiningArea(): MiningArea | null {
-    return this.miningArea;
+    // 保持している内部状態を外部から改変できないよう常にコピーを返す
+    return this.miningArea
+      ? {
+          start: { ...this.miningArea.start },
+          end:   { ...this.miningArea.end }
+        }
+      : null;
   }
 
   private static isValidCoord(c: Coord | undefined | null): c is Coord {
+    const MIN_Y = -64;
+    const MAX_Y = 320;
     return !!c
-      && Number.isFinite(c.x) && Number.isFinite(c.y) && Number.isFinite(c.z);
+      && Number.isInteger(c.x) && Number.isInteger(c.y) && Number.isInteger(c.z)
+      && c.y >= MIN_Y && c.y <= MAX_Y;
   }
 }

--- a/src/models/bot.model.ts
+++ b/src/models/bot.model.ts
@@ -1,6 +1,6 @@
 import { createClient, Client } from 'bedrock-protocol';
 import { v4 as uuidv4 } from 'uuid';
-import { BotState, BotSummary, Coord } from '../types/bot.types';
+import { BotState, BotSummary, Coord, MiningArea } from '../types/bot.types';
 
 /**
  * Minecraftのボットを表すクラス
@@ -15,6 +15,8 @@ export default class Bot {
 
   private position: Coord | null;
 
+  private miningArea: MiningArea | null;
+
   private ownerPlayerId: string | null;
 
   constructor() {
@@ -22,6 +24,7 @@ export default class Bot {
     this.state = BotState.Idle;
     this.client = null;
     this.position = null;
+    this.miningArea = null;
     this.ownerPlayerId = null;
   }
 
@@ -82,5 +85,29 @@ export default class Bot {
    */
   getPosition(): Coord | null {
     return this.position;
+  }
+
+  /**
+   * 採掘エリアの設定
+   * @param area MiningArea
+   * @throws Error 引数が不正な場合
+   */
+  setMiningArea(area: MiningArea): void {
+    if (!Bot.isValidCoord(area?.start) || !Bot.isValidCoord(area?.end)) {
+      throw new Error('InvalidRange');
+    }
+    this.miningArea = area;
+  }
+
+  /**
+   * 採掘エリアの取得
+   */
+  getMiningArea(): MiningArea | null {
+    return this.miningArea;
+  }
+
+  private static isValidCoord(c: Coord | undefined | null): c is Coord {
+    return !!c
+      && Number.isFinite(c.x) && Number.isFinite(c.y) && Number.isFinite(c.z);
   }
 }

--- a/src/services/bot.service.ts
+++ b/src/services/bot.service.ts
@@ -1,5 +1,5 @@
 import Bot from '../models/bot.model';
-import { BotSummary } from '../types/bot.types';
+import { BotSummary, MiningArea } from '../types/bot.types';
 
 /**
  * Botのサービスクラス
@@ -60,5 +60,20 @@ export default class BotService {
    */
   getAllBots(): BotSummary[] {
     return Array.from(this.bots.values()).map(bot => bot.getSummary());
+  }
+
+  /**
+   * 採掘エリアを設定する
+   * @param botId BotのID
+   * @param area 採掘エリア
+   * @throws Error 'BotNotFound' | 'InvalidRange'
+   */
+  setMiningArea(botId: string, area: MiningArea): void {
+    const bot = this.bots.get(botId);
+    if (!bot) {
+      throw new Error('BotNotFound');
+    }
+    // Bot.setMiningArea 内で InvalidRange を検証
+    bot.setMiningArea(area);
   }
 }

--- a/tests/unit/bot.controller.test.ts
+++ b/tests/unit/bot.controller.test.ts
@@ -153,5 +153,27 @@ describe('BotController', () => {
         error: { code: 'B002' }
       })).to.be.true;
     });
+    it('should return 500 with B000 on unexpected errors', () => {
+      const botId = 'bot-123';
+      const area = {
+        start: { x: 0, y: 60, z: 0 },
+        end: { x: 10, y: 70, z: 10 }
+      };
+
+      sinon.stub(botService, 'getBot').returns({} as any);
+      sinon.stub(botService, 'setMiningArea').throws(new Error('Boom'));
+
+      const req = {
+        params: { id: botId },
+        body: area
+      } as unknown as Request;
+
+      botController.setMiningArea(req, res as Response);
+
+      expect(statusStub.calledWith(500)).to.be.true;
+      expect(jsonStub.calledWithMatch({
+        error: { code: 'B000', message: 'Failed to set mining area' }
+      })).to.be.true;
+    });
   });
 });

--- a/tests/unit/bot.controller.test.ts
+++ b/tests/unit/bot.controller.test.ts
@@ -74,4 +74,84 @@ describe('BotController', () => {
       })).to.be.true;
     });
   });
+  describe('setMiningArea', () => {
+    let sendStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      // 既存の beforeEach で res/status/json は設定済み。ここで send を追加
+      sendStub = sinon.stub();
+      (res as any).send = sendStub;
+
+      // chainable を維持
+      sendStub.returns(res);
+      statusStub.returns(res);
+    });
+
+    it('should return 202 when area is set successfully', () => {
+      const botId = 'bot-123';
+      const area = {
+        start: { x: 0, y: 60, z: 0 },
+        end: { x: 10, y: 70, z: 10 }
+      };
+
+      // Bot が存在し、設定成功するケース
+      sinon.stub(botService, 'getBot').returns({} as any);
+      sinon.stub(botService, 'setMiningArea').returns();
+
+      const req = {
+        params: { id: botId },
+        body: area
+      } as unknown as Request;
+
+      botController.setMiningArea(req, res as Response);
+
+      expect(statusStub.calledWith(202)).to.be.true;
+      expect(sendStub.calledOnce).to.be.true;
+    });
+
+    it('should return 400 with B001 when range is invalid', () => {
+      const botId = 'bot-123';
+      const area = {
+        start: { x: NaN, y: 60, z: 0 }, // invalid
+        end: { x: 10, y: 70, z: 10 }
+      };
+
+      sinon.stub(botService, 'getBot').returns({} as any);
+      sinon.stub(botService, 'setMiningArea').throws(new Error('InvalidRange'));
+
+      const req = {
+        params: { id: botId },
+        body: area
+      } as unknown as Request;
+
+      botController.setMiningArea(req, res as Response);
+
+      expect(statusStub.calledWith(400)).to.be.true;
+      expect(jsonStub.calledWithMatch({
+        error: { code: 'B001', message: 'InvalidRange' }
+      })).to.be.true;
+    });
+
+    it('should return 404 with B002 when bot not found', () => {
+      const botId = 'missing-bot';
+      const area = {
+        start: { x: 0, y: 60, z: 0 },
+        end: { x: 10, y: 70, z: 10 }
+      };
+
+      sinon.stub(botService, 'getBot').returns(undefined);
+
+      const req = {
+        params: { id: botId },
+        body: area
+      } as unknown as Request;
+
+      botController.setMiningArea(req, res as Response);
+
+      expect(statusStub.calledWith(404)).to.be.true;
+      expect(jsonStub.calledWithMatch({
+        error: { code: 'B002' }
+      })).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
Implements acceptance criteria:\n- POST /bots/{id}/area returns 202 Accepted\n- StateDB (in-memory) Bot record holds range\n- CLI setarea prints 'Area set'\n- Error B001 InvalidRange applied\n\nAPI per [openapi.yaml](docs/03_design/api/openapi.yaml)\nErrors per [error_catalog.md](docs/03_design/api/error_catalog.md)\n\nNotes:\n- bedrock-protocol is integrated in [Bot](src/models/bot.model.ts:1); this change adds area management only.\n- In-memory Map used as StateDB; sqlite migration deferred to another issue to avoid scope creep.\n\nLocal checks:\n- lint: warnings only\n- tests: passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ボットの採掘エリアを設定するCLIコマンドを追加（座標指定で実行、成功時に "Area set" 表示）
  - APIに POST /bots/:id/area を追加し、受理時に202を返却
- 変更
  - ボットに採掘エリアの保存・取得・検証を実装
  - 不正な範囲は400（B001）、未存在ボットは404（B002）、その他は500（B000）を返却
- テスト
  - エンドポイントの成功・各種エラー応答を検証するユニットテストを追加
- ドキュメント
  - 実装・テスト経緯を説明するセッション記録を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->