### PR TITLE
feat: Tool durability monitor & stop on break (US-001-5)

### DIFF
--- a/docs/00_practice/ai_session/2025-08-17-1111-tool-durability-monitor.md
+++ b/docs/00_practice/ai_session/2025-08-17-1111-tool-durability-monitor.md
@@ -1,0 +1,58 @@
+# Tool durability monitor & stop on break (US-001-5) — セッション記録
+
+このセッションでは、GitHub Issue #6 に基づく「ツール耐久監視と破損時停止機能」の実装を完了した過程を記録します。関連ファイルの変更点、意思決定、今後の対応を時系列で整理します。
+
+##Summary
+- ツールの耐久度を監視する ToolManager を実装し、耐久度が 0 となった場合に MiningEngine に停止指示を送信し、チャット通知を実行する機能を追加した。
+- MiningEngine に stopDig() を追加し、停止時には採掘キューをクリアして停止状態を反映するようにした。
+- Bedrock プロトコルを介して Minecraft サーバーへチャット通知を送る ChatNotifier を実装した。
+- これらの新機能を対象にユニットテストを追加・更新し、CI/Lint チェックが通る状態を確保した。
+- 作業ブランチは feat/6-tool-durability-monitor として作成・Push し、Pull Request を作成済み。
+
+関連リンク
+- PR: [feat: Tool durability monitor & stop on break (US-001-5)](https://github.com/u-keiya/Tsuruhashi/pull/16)
+- Issue: #6 (Tool durability monitor)
+- USDM: US-001-5
+- 設計書: [`docs/03_design/diagrams/sequence/tool_break_swap.puml`](docs/03_design/diagrams/sequence/tool_break_swap.puml:1)
+
+関連ファイル（変更点の参照用リンク）
+- [`src/engine/toolManager.ts`](src/engine/toolManager.ts:1)
+- [`src/engine/miningEngine.ts`](src/engine/miningEngine.ts:1)
+- [`src/engine/chatNotifier.ts`](src/engine/chatNotifier.ts:1)
+- [`tests/unit/toolManager.test.ts`](tests/unit/toolManager.test.ts:1)
+- [`docs/03_design/diagrams/sequence/tool_break_swap.puml`](docs/03_design/diagrams/sequence/tool_break_swap.puml:1)
+
+##User Requirement
+- ツールの耐久度を監視し、耐久度が 0 になったら MiningEngine に停止要求を送ること。
+- 停止時にはチャット通知を送信すること（日本語メッセージ: "ツール切れで停止"）。
+- MiningEngine は stopDig() を提供し、採掘を停止して採掘キューをクリアすること。
+- Bedrock-protocol を用いて Minecraft サーバーへ通知を送ること。
+- ユニットテストを追加・更新して、耐久 1 → 0 のケースで停止が呼ばれることを検証すること。
+
+##Key Decisions
+- ToolManager.notifyUse(blockHardness) で耐久を減らし、0 になった場合に stopDig() とチャット通知を実行する方針を採択。実装ファイル: src/engine/toolManager.ts
+- MiningEngine.stopDig() を追加し、採掘停止時には miningQueue をクリアし、状態を Idle に戻す設計を採用。実装ファイル: src/engine/miningEngine.ts
+- ChatNotifier は bedrock-protocol の text パケットを用いてチャットを送信する。実装ファイル: src/engine/chatNotifier.ts
+- テストは Jest へ移行せず、既存のテスト環境に合わせて Sinon + Chai ベースのテストを拡張・追加。更新ファイル: tests/unit/toolManager.test.ts, tests/unit/miningEngine.test.ts
+
+##Action Items
+- [x] Issue #6 の理解と要件整理（USDM: US-001-5、PR #16 対応含む）
+- [x] 設計書の確認（sequence/tool_break_swap.puml）
+- [x] コードベースの理解とブランチ作成
+- [x] ToolManager クラスの実装
+- [x] MiningEngine に stopDig() を追加
+- [x] ChatNotifier の実装
+- [x] 連携テストの拡張（toolManager.test.ts、miningEngine.test.ts）
+- [x] Lint/CI チェックの実行と修正
+- [x] GitHub へプルリクエストを作成・プッシュ
+- [x] セッションのドキュメント化（本セッション記録の作成）
+
+## References
+- USDM: US-001-5
+- Issue: #6
+- PR: https://github.com/u-keiya/Tsuruhashi/pull/16
+- Design reference: docs/03_design/diagrams/sequence/tool_break_swap.puml
+
+注意:
+- 本セッションの成果物は docs/00_practice/ai_session/ に日付付きファイルとして記録します。今後、 Confluence 風の要約や ADR の追加も検討します。
+- 変更済みファイルの差分は、後続のコミット履歴とともにレビュアーへ提示される想定です。

--- a/src/engine/chatNotifier.ts
+++ b/src/engine/chatNotifier.ts
@@ -1,0 +1,30 @@
+import { ClientLike, TextPayload } from './miningEngine';
+
+/**
+ * ChatNotifier
+ * - Minecraftサーバーにチャットメッセージを送信
+ */
+export default class ChatNotifier {
+  private readonly client: ClientLike;
+
+  constructor(client: ClientLike) {
+    this.client = client;
+  }
+
+  /**
+   * チャットメッセージを送信
+   * @param message 送信するメッセージ
+   */
+  sendMessage(message: string): void {
+    // bedrock-protocolでチャットメッセージを送信
+    // 実際の実装では text パケットを使用
+    const payload: TextPayload = {
+      type: 'chat',
+      message,
+      source_name: '',
+      xuid: '',
+      platform_chat_id: ''
+    };
+    this.client.queue('text', payload);
+  }
+}

--- a/src/engine/chatNotifier.ts
+++ b/src/engine/chatNotifier.ts
@@ -1,10 +1,11 @@
 import { ClientLike, TextPayload } from './miningEngine';
+import { ChatNotifierLike } from './ports';
 
 /**
  * ChatNotifier
  * - Minecraftサーバーにチャットメッセージを送信
  */
-export default class ChatNotifier {
+export default class ChatNotifier implements ChatNotifierLike {
   private readonly client: ClientLike;
 
   constructor(client: ClientLike) {

--- a/src/engine/miningEngine.ts
+++ b/src/engine/miningEngine.ts
@@ -12,11 +12,19 @@ export interface PlayerActionPayload {
   face?: number;
 }
 
+export interface TextPayload {
+  type: string;
+  message: string;
+  source_name: string;
+  xuid: string;
+  platform_chat_id: string;
+}
+
 export interface ClientLike {
   // bedrock-protocol client compatible (we only need queue in unit tests)
   queue(
-    packetName: 'move_player' | 'player_action',
-    payload: MovePlayerPayload | PlayerActionPayload
+    packetName: 'move_player' | 'player_action' | 'text',
+    payload: MovePlayerPayload | PlayerActionPayload | TextPayload
   ): void;
 }
 
@@ -28,6 +36,10 @@ export interface StateDBLike {
 
 export interface ToolManagerLike {
   notifyUse(blockHardness: number): void;
+}
+
+export interface ChatNotifierLike {
+  sendMessage(message: string): void;
 }
 
 /**
@@ -60,9 +72,13 @@ export class MiningEngine {
   // === Auto Mining ===
   private toolManager?: ToolManagerLike;
 
+  private chatNotifier?: ChatNotifierLike;
+
   private miningQueue: Coord[] = [];
 
   private minedBlocks: number = 0;
+
+  private isStopped: boolean = false;
 
   constructor(params: {
     botId: string;
@@ -70,12 +86,14 @@ export class MiningEngine {
     stateDB: StateDBLike;
     initialPosition: Coord;
     toolManager?: ToolManagerLike;
+    chatNotifier?: ChatNotifierLike;
   }) {
     this.botId = params.botId;
     this.client = params.client;
     this.stateDB = params.stateDB;
     this.currentPos = { ...params.initialPosition };
     this.toolManager = params.toolManager;
+    this.chatNotifier = params.chatNotifier;
   }
 
   getState(): BotState {
@@ -133,6 +151,22 @@ export class MiningEngine {
    */
   getMinedBlocks(): number {
     return this.minedBlocks;
+  }
+
+  /**
+   * 採掘を停止する（ツール破損時など）
+   */
+  stopDig(): void {
+    this.isStopped = true;
+    this.state = BotState.Idle;
+    this.miningQueue = []; // 採掘キューをクリア
+  }
+
+  /**
+   * 停止状態を確認
+   */
+  isMiningstopped(): boolean {
+    return this.isStopped;
   }
 
   /**
@@ -203,7 +237,7 @@ export class MiningEngine {
    * - 実機では Bedrock Server からの Ack をイベントで受け取る
    */
   private async scheduleNextMining(): Promise<void> {
-      if (this.miningQueue.length === 0) return;
+      if (this.miningQueue.length === 0 || this.isStopped) return;
       const block = this.miningQueue.shift() as Coord;
   
       // 採掘開始

--- a/src/engine/miningEngine.ts
+++ b/src/engine/miningEngine.ts
@@ -1,5 +1,6 @@
 import { BotState, Coord, MiningArea } from '../types/bot.types';
 import { PathFinder } from './pathfinder';
+import { ChatNotifierLike } from './ports';
 
 export interface MovePlayerPayload {
   position: Coord;
@@ -38,9 +39,6 @@ export interface ToolManagerLike {
   notifyUse(blockHardness: number): void;
 }
 
-export interface ChatNotifierLike {
-  sendMessage(message: string): void;
-}
 
 /**
  * MiningEngine
@@ -165,7 +163,7 @@ export class MiningEngine {
   /**
    * 停止状態を確認
    */
-  isMiningstopped(): boolean {
+  isMiningStopped(): boolean {
     return this.isStopped;
   }
 

--- a/src/engine/ports.ts
+++ b/src/engine/ports.ts
@@ -1,0 +1,3 @@
+export interface ChatNotifierLike {
+  sendMessage(message: string): void;
+}

--- a/src/engine/toolManager.ts
+++ b/src/engine/toolManager.ts
@@ -1,0 +1,82 @@
+export interface Tool {
+  id: string;
+  durability: number;
+  maxDurability: number;
+}
+
+export interface ChatNotifierLike {
+  sendMessage(message: string): void;
+}
+
+export interface MiningEngineLike {
+  stopDig(): void;
+}
+
+/**
+ * ToolManager
+ * - ツールの耐久度を監視
+ * - 耐久度が0になったらMiningEngineに停止要求
+ * - チャット通知を送信
+ */
+export class ToolManager {
+  private currentTool: Tool | null = null;
+
+  private readonly chatNotifier: ChatNotifierLike;
+
+  private readonly miningEngine: MiningEngineLike;
+
+  constructor(params: {
+    chatNotifier: ChatNotifierLike;
+    miningEngine: MiningEngineLike;
+    initialTool?: Tool;
+  }) {
+    this.chatNotifier = params.chatNotifier;
+    this.miningEngine = params.miningEngine;
+    this.currentTool = params.initialTool || null;
+  }
+
+  /**
+   * ツールの使用を通知し、耐久度を減らす
+   * @param blockHardness ブロックの硬度（耐久度減少量）
+   */
+  notifyUse(blockHardness: number): void {
+    if (!this.currentTool) {
+      return;
+    }
+
+    // 耐久度を減らす
+    this.currentTool.durability = Math.max(0, this.currentTool.durability - blockHardness);
+
+    // 耐久度が0になった場合の処理
+    if (this.currentTool.durability === 0) {
+      this.handleToolBreak();
+    }
+  }
+
+  /**
+   * 現在のツール情報を取得
+   */
+  getCurrentTool(): Tool | null {
+    return this.currentTool ? { ...this.currentTool } : null;
+  }
+
+  /**
+   * ツールを設定
+   */
+  setTool(tool: Tool): void {
+    this.currentTool = { ...tool };
+  }
+
+  /**
+   * ツール破損時の処理
+   * - MiningEngineに停止要求
+   * - チャット通知
+   */
+  private handleToolBreak(): void {
+    // MiningEngineに停止要求
+    this.miningEngine.stopDig();
+    
+    // チャット通知
+    this.chatNotifier.sendMessage('ツール切れで停止');
+  }
+}

--- a/src/engine/toolManager.ts
+++ b/src/engine/toolManager.ts
@@ -1,11 +1,9 @@
+import { ChatNotifierLike } from './ports';
+
 export interface Tool {
   id: string;
   durability: number;
   maxDurability: number;
-}
-
-export interface ChatNotifierLike {
-  sendMessage(message: string): void;
 }
 
 export interface MiningEngineLike {
@@ -41,6 +39,15 @@ export class ToolManager {
    */
   notifyUse(blockHardness: number): void {
     if (!this.currentTool) {
+      return;
+    }
+
+    // 無効な減衰量は無視
+    if (!Number.isFinite(blockHardness) || blockHardness <= 0) {
+      return;
+    }
+    // すでに破損済みなら何もしない（重複停止/通知の抑止）
+    if (this.currentTool.durability <= 0) {
       return;
     }
 

--- a/tests/unit/miningEngine.test.ts
+++ b/tests/unit/miningEngine.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { MiningEngine, ClientLike, StateDBLike, ToolManagerLike, ChatNotifierLike } from '../../src/engine/miningEngine';
+import { MiningEngine, ClientLike, StateDBLike, ToolManagerLike } from '../../src/engine/miningEngine';
 import { BotState, Coord, MiningArea } from '../../src/types/bot.types';
 
 describe('MiningEngine', () => {
@@ -252,7 +252,7 @@ describe('MiningEngine - Auto mining loop (Issue #5 US-001-4)', () => {
       engine.stopDig();
 
       // Assert
-      expect(engine.isMiningstopped()).to.be.true;
+      expect(engine.isMiningStopped()).to.be.true;
       expect(engine.getState()).to.equal(BotState.Idle);
 
       // 停止後は採掘が実行されない

--- a/tests/unit/toolManager.test.ts
+++ b/tests/unit/toolManager.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { ToolManager, Tool, ChatNotifierLike, MiningEngineLike } from '../../src/engine/toolManager';
+import { ToolManager, Tool, MiningEngineLike } from '../../src/engine/toolManager';
+import { ChatNotifierLike } from '../../src/engine/ports';
 
 describe('ToolManager', () => {
   let toolManager: ToolManager;
@@ -75,7 +76,7 @@ describe('ToolManager', () => {
 
       // Assert
       expect(mockMiningEngine.stopDig.calledOnce).to.be.true;
-      expect(mockChatNotifier.sendMessage.calledWith('ツール切れで停止')).to.be.true;
+      expect(mockChatNotifier.sendMessage.calledOnceWith('ツール切れで停止')).to.be.true;
     });
 
     it('should handle case when durability goes from 1 to 0', () => {

--- a/tests/unit/toolManager.test.ts
+++ b/tests/unit/toolManager.test.ts
@@ -1,0 +1,210 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ToolManager, Tool, ChatNotifierLike, MiningEngineLike } from '../../src/engine/toolManager';
+
+describe('ToolManager', () => {
+  let toolManager: ToolManager;
+  let mockChatNotifier: ChatNotifierLike & { sendMessage: sinon.SinonSpy };
+  let mockMiningEngine: MiningEngineLike & { stopDig: sinon.SinonSpy };
+
+  beforeEach(() => {
+    mockChatNotifier = {
+      sendMessage: sinon.spy()
+    } as unknown as ChatNotifierLike & { sendMessage: sinon.SinonSpy };
+
+    mockMiningEngine = {
+      stopDig: sinon.spy()
+    } as unknown as MiningEngineLike & { stopDig: sinon.SinonSpy };
+
+    toolManager = new ToolManager({
+      chatNotifier: mockChatNotifier,
+      miningEngine: mockMiningEngine
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('notifyUse', () => {
+    it('should reduce tool durability when notifyUse is called', () => {
+      // Arrange
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 5,
+        maxDurability: 10
+      };
+      toolManager.setTool(tool);
+
+      // Act
+      toolManager.notifyUse(2);
+
+      // Assert
+      const currentTool = toolManager.getCurrentTool();
+      expect(currentTool?.durability).to.equal(3);
+    });
+
+    it('should not reduce durability below 0', () => {
+      // Arrange
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 1,
+        maxDurability: 10
+      };
+      toolManager.setTool(tool);
+
+      // Act
+      toolManager.notifyUse(5);
+
+      // Assert
+      const currentTool = toolManager.getCurrentTool();
+      expect(currentTool?.durability).to.equal(0);
+    });
+
+    it('should call stopDig and send chat message when durability reaches 0', () => {
+      // Arrange
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 1,
+        maxDurability: 10
+      };
+      toolManager.setTool(tool);
+
+      // Act
+      toolManager.notifyUse(1);
+
+      // Assert
+      expect(mockMiningEngine.stopDig.calledOnce).to.be.true;
+      expect(mockChatNotifier.sendMessage.calledWith('ツール切れで停止')).to.be.true;
+    });
+
+    it('should handle case when durability goes from 1 to 0', () => {
+      // Arrange - US-001-5 要件: 耐久 1 → 0 になるケースで停止が呼ばれる
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 1,
+        maxDurability: 10
+      };
+      toolManager.setTool(tool);
+
+      // Act
+      toolManager.notifyUse(1);
+
+      // Assert
+      const currentTool = toolManager.getCurrentTool();
+      expect(currentTool?.durability).to.equal(0);
+      expect(mockMiningEngine.stopDig.calledOnce).to.be.true;
+      expect(mockChatNotifier.sendMessage.calledWith('ツール切れで停止')).to.be.true;
+    });
+
+    it('should not call stopDig when durability is still above 0', () => {
+      // Arrange
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 3,
+        maxDurability: 10
+      };
+      toolManager.setTool(tool);
+
+      // Act
+      toolManager.notifyUse(1);
+
+      // Assert
+      expect(mockMiningEngine.stopDig.called).to.be.false;
+      expect(mockChatNotifier.sendMessage.called).to.be.false;
+    });
+
+    it('should do nothing when no tool is set', () => {
+      // Act
+      toolManager.notifyUse(1);
+
+      // Assert
+      expect(mockMiningEngine.stopDig.called).to.be.false;
+      expect(mockChatNotifier.sendMessage.called).to.be.false;
+    });
+  });
+
+  describe('getCurrentTool', () => {
+    it('should return null when no tool is set', () => {
+      // Act
+      const result = toolManager.getCurrentTool();
+
+      // Assert
+      expect(result).to.be.null;
+    });
+
+    it('should return a copy of the current tool', () => {
+      // Arrange
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 5,
+        maxDurability: 10
+      };
+      toolManager.setTool(tool);
+
+      // Act
+      const result = toolManager.getCurrentTool();
+
+      // Assert
+      expect(result).to.deep.equal(tool);
+      expect(result).to.not.equal(tool); // Should be a copy, not the same reference
+    });
+  });
+
+  describe('setTool', () => {
+    it('should set the tool correctly', () => {
+      // Arrange
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 5,
+        maxDurability: 10
+      };
+
+      // Act
+      toolManager.setTool(tool);
+
+      // Assert
+      const currentTool = toolManager.getCurrentTool();
+      expect(currentTool).to.deep.equal(tool);
+    });
+
+    it('should create a copy of the tool to prevent external modification', () => {
+      // Arrange
+      const tool: Tool = {
+        id: 'pickaxe-1',
+        durability: 5,
+        maxDurability: 10
+      };
+
+      // Act
+      toolManager.setTool(tool);
+      tool.durability = 0; // Modify original
+
+      // Assert
+      const currentTool = toolManager.getCurrentTool();
+      expect(currentTool?.durability).to.equal(5); // Should not be affected
+    });
+  });
+
+  describe('constructor with initial tool', () => {
+    it('should set initial tool when provided', () => {
+      // Arrange
+      const initialTool: Tool = {
+        id: 'pickaxe-1',
+        durability: 8,
+        maxDurability: 10
+      };
+
+      // Act
+      const toolManagerWithInitialTool = new ToolManager({
+        chatNotifier: mockChatNotifier,
+        miningEngine: mockMiningEngine,
+        initialTool: initialTool
+      });
+
+      // Assert
+      const currentTool = toolManagerWithInitialTool.getCurrentTool();
+      expect(currentTool).to.deep.equal(initialTool);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
GitHub Issue #6 の実装: ツール耐久監視と破損時停止機能

## 実装内容
- **ToolManager クラス**: ツールの耐久度を監視し、0になったときにMiningEngineに停止要求を送信
- **MiningEngine.stopDig()**: 採掘を停止し、採掘キューをクリアする機能
- **ChatNotifier クラス**: Minecraftサーバーにチャットメッセージを送信する機能
- **包括的なユニットテスト**: 全ての新機能に対するテストを追加

## 受入基準の達成
- [x] ToolManager に notifyUse で消耗を計算し耐久 0 を検出
- [x] 耐久 0 → MiningEngine.stopDig を呼び出す
- [x] Bot がチャットで "ツール切れで停止" を送信
- [x] unit test: 耐久 1 → 0 になるケースで停止が呼ばれる

## テスト結果
- ✅ 全27テストが成功
- ✅ Lintチェック通過（新規コードにエラーなし）

## 関連
- Closes #6
- USDM: US-001-5
- 設計書: `docs/03_design/diagrams/sequence/tool_break_swap.puml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ゲーム内チャット通知に対応し、チャットメッセージの自動送信が可能に。
  - 採掘の緊急停止機能を追加。停止後は新たな採掘動作をブロックし、停止状態の確認が可能に。
  - ツール耐久度管理を追加。耐久が0になると自動で採掘を停止し、チャットで通知する挙動を実装。

- テスト
  - 採掘停止とキュー制御の挙動を検証するテストを追加。
  - ツール管理（耐久減少、停止トリガー、参照の不変性、初期化）のテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->