### PR TITLE
feat: DELETE /bots/{id} – physical bot deletion (US-005)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,4 +22,14 @@ module.exports = {
     },
   },
   ignorePatterns: ['dist/', 'node_modules/', '**/*.js'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
+  },
 };

--- a/docs/00_practice/ai_session/2025-08-17-1529-delete-bot-session.md
+++ b/docs/00_practice/ai_session/2025-08-17-1529-delete-bot-session.md
@@ -1,0 +1,61 @@
+## Summary
+2025-08-17 15:29 JST のセッション記録 — 実装作業: DELETE /bots/{id} (US-005)
+- このセッションでは管理者向け Bot 物理削除機能を実装し、単体テストを追加、ローカル機能ブランチを作成しました。
+- 実装は DeletionManager を新規追加し、サービス／コントローラーを更新、関連型定義とテストを追加しています。
+- ユニットテストはローカルで実行し、57 件のテストが全て成功しました。Lint の警告/残課題を記録しています。
+
+### User Requirement
+- Issue: feat: DELETE /bots/{id} – physical bot deletion (US-005)
+- 要件: 管理者専用 API で Bot を graceful stop → DB レコード削除 → インベントリ削除 → BotDeleted イベント publish
+- 受け入れ基準: 204/404/403 のパスをテスト
+
+### Key Decisions
+- DeletionManager コンポーネントを追加して削除フローを担当させる（ADR: [`docs/03_design/adr/0004-physical-bot-deletion.md`](docs/03_design/adr/0004-physical-bot-deletion.md:1)）。
+- Control API の DELETE /bots/{botId} は既に OpenAPI に定義済み（参照: [`docs/03_design/api/openapi.yaml`](docs/03_design/api/openapi.yaml:143)）。
+- 削除 API は Admin 権限のみ許可。現時点ではヘッダー `x-admin-role` をテスト用に使用する簡易実装。
+
+### Implementation (変更点)
+- 新規追加: [`src/engine/deletionManager.ts`](src/engine/deletionManager.ts:1) — DeletionManager 実装（graceful stop / DB 削除 stub / ファイル削除 stub / イベント publish）。
+- 修正: [`src/services/bot.service.ts`](src/services/bot.service.ts:1) — DeletionManager を利用するよう deleteBot を非同期化。
+- 修正: [`src/controllers/bot.controller.ts`](src/controllers/bot.controller.ts:1) — 管理者チェックを追加し deleteBot を async に変更。
+- 追加型: [`src/types/bot.types.ts`](src/types/bot.types.ts:1) — BotDeletedEvent / DeleteBotRequest を追加。
+- テスト追加・更新: [`tests/unit/deletionManager.test.ts`](tests/unit/deletionManager.test.ts:1)、[`tests/unit/bot.controller.test.ts`](tests/unit/bot.controller.test.ts:1) を更新／追加。
+- ブランチ作成（ローカル）: feat/8-delete-bot-api （GitHub でのリモートブランチ作成は拒否されました）。
+
+### Commands 実行ログ（主なもの）
+- ブランチ作成: `git checkout -b feat/8-delete-bot-api`
+- テスト: `npm test` → 57 passing
+- Lint: `npm run lint` → 一部ルール違反を修正中（詳細は下）
+
+### Test Results
+- 全ユニットテスト: 57 passing（`npm test` ローカル実行結果を保存）
+- 追加した deletion 関連テストは成功（[`tests/unit/deletionManager.test.ts`](tests/unit/deletionManager.test.ts:1) を参照）
+
+### Lint & Known Issues
+- 実行: `npm run lint` の結果、いくつかの警告/エラーを検出し大半を修正済み。
+- 残課題（現状未修正）:
+  - [`src/engine/progressReporter.ts`](src/engine/progressReporter.ts:1) と [`src/engine/scheduler.ts`](src/engine/scheduler.ts:1) に console.log の警告が残る。
+  - 一部の ESLint ルール（TypeScript バージョンの警告）について環境の TS バージョンが推奨範囲外（5.9.2）。CI 環境での確認が必要。
+
+### Action Items
+- [ ] Push feature branch `feat/8-delete-bot-api` と PR を作成する（Role: Dev）
+- [ ] CI 上で lint とテストを通すため、残る console.log 警告を削除または logger に置換する（Role: Dev）
+- [ ] 実運用の認証連携に差し替え：`extractDeleteRequest` を JWT/認証ミドルウェアへ移行（Role: Dev / SA）
+- [ ] DeletionManager の DB/ファイル削除の TODO を実実装（SQLite / filesystem）（Role: Dev）
+- [ ] 監査イベントの永続先を決めて実装（ADR0004 Open Issues）（Role: SA / RM）
+
+### References
+- Issue: [`https://github.com/u-keiya/Tsuruhashi/issues/8`](https://github.com/u-keiya/Tsuruhashi/issues/8)  
+- ADR: [`docs/03_design/adr/0004-physical-bot-deletion.md`](docs/03_design/adr/0004-physical-bot-deletion.md:1)  
+- OpenAPI: [`docs/03_design/api/openapi.yaml`](docs/03_design/api/openapi.yaml:143)  
+- 主要変更ファイル一覧:
+  - [`src/engine/deletionManager.ts`](src/engine/deletionManager.ts:1)  
+  - [`src/services/bot.service.ts`](src/services/bot.service.ts:1)  
+  - [`src/controllers/bot.controller.ts`](src/controllers/bot.controller.ts:1)  
+  - [`src/types/bot.types.ts`](src/types/bot.types.ts:1)  
+
+### Open Questions
+- (PO/SA) 監査イベントの永続先はどこにしますか？（log/DB/message-bus）
+- (Ops) 本番で推奨する TypeScript バージョンと CI 設定の差し替え方を決めてください。
+
+End of session.

--- a/src/engine/deletionManager.ts
+++ b/src/engine/deletionManager.ts
@@ -61,22 +61,20 @@ export default class DeletionManager extends EventEmitter {
    * State Store(SQLite)からBotレコードを削除
    * @param botId BotのID
    */
-  private static async removeBotRecord(botId: string): Promise<void> {
+  private static async removeBotRecord(_botId: string): Promise<void> {
     // TODO: SQLite実装時に実際のDB削除処理を追加
-    // console.log(`Removing bot record from database: ${botId}`);
+    // console.log(`Removing bot record from database: ${_botId}`);
     // Suppress unused parameter warning
-    botId;
   }
 
   /**
    * Botのインベントリファイルを物理削除
    * @param botId BotのID
    */
-  private static async deleteInventoryFiles(botId: string): Promise<void> {
+  private static async deleteInventoryFiles(_botId: string): Promise<void> {
     // TODO: 実際のファイルシステム操作を実装
-    // console.log(`Deleting inventory files for bot: ${botId}`);
+    // console.log(`Deleting inventory files for bot: ${_botId}`);
     // Suppress unused parameter warning
-    botId;
   }
 
   /**

--- a/src/engine/deletionManager.ts
+++ b/src/engine/deletionManager.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from 'events';
+import { BotDeletedEvent } from '../types/bot.types';
+import Bot from '../models/bot.model';
+
+/**
+ * Bot物理削除を管理するクラス
+ * ADR0004: Physical Bot Deletion
+ * US-005: 不要になったBotを削除できる
+ */
+export default class DeletionManager extends EventEmitter {
+  /**
+   * Botを物理削除する
+   * @param bot 削除対象のBot
+   * @param deletedBy 削除を実行したユーザー（管理者）
+   */
+  async deleteBot(bot: Bot, deletedBy?: string): Promise<void> {
+    const botId = bot.getSummary().id;
+
+    try {
+      // 1. Graceful stop - Botプロセスを停止
+      await DeletionManager.gracefulStop(bot);
+
+      // 2. State Store(SQLite)からレコード削除
+      // TODO: 実際のSQLite実装時に追加
+      await DeletionManager.removeBotRecord(botId);
+
+      // 3. インベントリファイルを物理削除
+      await DeletionManager.deleteInventoryFiles(botId);
+
+      // 4. BotDeletedイベントをpublish
+      const event: BotDeletedEvent = {
+        botId,
+        timestamp: new Date(),
+        deletedBy
+      };
+      this.publishBotDeletedEvent(event);
+
+    } catch (error) {
+      // console.error(`Failed to delete bot ${botId}:`, error);
+      throw new Error(`Bot deletion failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Botプロセスを優雅に停止する
+   * @param bot 停止対象のBot
+   */
+  private static async gracefulStop(bot: Bot): Promise<void> {
+    return new Promise((resolve) => {
+      // Botの切断処理を実行
+      bot.disconnect();
+      
+      // 少し待機してプロセスが完全に終了するのを待つ
+      setTimeout(() => {
+        resolve();
+      }, 1000);
+    });
+  }
+
+  /**
+   * State Store(SQLite)からBotレコードを削除
+   * @param botId BotのID
+   */
+  private static async removeBotRecord(botId: string): Promise<void> {
+    // TODO: SQLite実装時に実際のDB削除処理を追加
+    // console.log(`Removing bot record from database: ${botId}`);
+    // Suppress unused parameter warning
+    botId;
+  }
+
+  /**
+   * Botのインベントリファイルを物理削除
+   * @param botId BotのID
+   */
+  private static async deleteInventoryFiles(botId: string): Promise<void> {
+    // TODO: 実際のファイルシステム操作を実装
+    // console.log(`Deleting inventory files for bot: ${botId}`);
+    // Suppress unused parameter warning
+    botId;
+  }
+
+  /**
+   * BotDeletedイベントをpublish（監査用）
+   * @param event BotDeletedイベント
+   */
+  private publishBotDeletedEvent(event: BotDeletedEvent): void {
+    // EventEmitterを使用してイベントを発行
+    this.emit('botDeleted', event);
+    
+    // 監査ログ出力
+    // console.log(`Bot deleted: ${JSON.stringify(event)}`);
+  }
+}

--- a/src/services/bot.service.ts
+++ b/src/services/bot.service.ts
@@ -1,5 +1,6 @@
 import Bot from '../models/bot.model';
 import { BotSummary, MiningArea } from '../types/bot.types';
+import DeletionManager from '../engine/deletionManager';
 
 /**
  * Botのサービスクラス
@@ -8,8 +9,11 @@ import { BotSummary, MiningArea } from '../types/bot.types';
 export default class BotService {
   private bots: Map<string, Bot>;
 
+  private deletionManager: DeletionManager;
+
   constructor() {
     this.bots = new Map();
+    this.deletionManager = new DeletionManager();
   }
 
   /**
@@ -38,15 +42,21 @@ export default class BotService {
   }
 
   /**
-   * 指定したIDのBotを削除する
+   * 指定したIDのBotを削除する（物理削除）
    * @param botId BotのID
+   * @param deletedBy 削除を実行したユーザー（管理者）
    */
-  deleteBot(botId: string): void {
+  async deleteBot(botId: string, deletedBy?: string): Promise<void> {
     const bot = this.bots.get(botId);
-    if (bot) {
-      bot.disconnect();
-      this.bots.delete(botId);
+    if (!bot) {
+      throw new Error('BotNotFound');
     }
+
+    // DeletionManagerを使用して物理削除を実行
+    await this.deletionManager.deleteBot(bot, deletedBy);
+    
+    // メモリ上のBotインスタンスを削除
+    this.bots.delete(botId);
   }
 
   /**

--- a/src/types/bot.types.ts
+++ b/src/types/bot.types.ts
@@ -68,3 +68,20 @@ export interface MiningStats {
   currentY: number;
   targetY: number;
 }
+
+/**
+ * Bot削除イベント（US-005）
+ */
+export interface BotDeletedEvent {
+  botId: string;
+  timestamp: Date;
+  deletedBy?: string; // 削除を実行したユーザー（管理者）
+}
+
+/**
+ * 削除リクエストの権限情報
+ */
+export interface DeleteBotRequest {
+  isAdmin: boolean;
+  userId?: string;
+}

--- a/tests/unit/bot.controller.test.ts
+++ b/tests/unit/bot.controller.test.ts
@@ -200,12 +200,13 @@ describe('BotController', () => {
       };
 
       sinon.stub(botService, 'getBot').returns(mockBot as any);
-      sinon.stub(botService, 'deleteBot').resolves();
+      const deleteStub = sinon.stub(botService, 'deleteBot').resolves();
 
       await botController.deleteBot(req as Request, res as Response);
 
       expect(statusStub.calledWith(204)).to.be.true;
       expect(sendStub.calledOnce).to.be.true;
+      expect(deleteStub.calledWith(botId, 'admin-user')).to.be.true;
     });
 
     it('should return 403 when user is not admin', async () => {
@@ -220,12 +221,16 @@ describe('BotController', () => {
         }
       };
 
+      const getBotSpy = sinon.spy(botService, 'getBot');
+      const deleteSpy = sinon.spy(botService, 'deleteBot');
       await botController.deleteBot(req as Request, res as Response);
 
       expect(statusStub.calledWith(403)).to.be.true;
       expect(jsonStub.calledWith({
         error: 'Forbidden – requires Admin role'
       })).to.be.true;
+      expect(getBotSpy.notCalled).to.be.true;
+      expect(deleteSpy.notCalled).to.be.true;
     });
 
     it('should return 404 when bot is not found', async () => {

--- a/tests/unit/deletionManager.test.ts
+++ b/tests/unit/deletionManager.test.ts
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import DeletionManager from '../../src/engine/deletionManager';
+import Bot from '../../src/models/bot.model';
+import { BotDeletedEvent, BotState } from '../../src/types/bot.types';
+
+describe('DeletionManager', () => {
+  let deletionManager: DeletionManager;
+  let mockBot: Bot;
+  let disconnectStub: sinon.SinonStub;
+  let getSummaryStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    deletionManager = new DeletionManager();
+    mockBot = new Bot();
+    
+    // Botのメソッドをスタブ化
+    disconnectStub = sinon.stub(mockBot, 'disconnect');
+    getSummaryStub = sinon.stub(mockBot, 'getSummary').returns({
+      id: 'test-bot-id',
+      state: BotState.Idle
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('deleteBot', () => {
+    it('should successfully delete a bot', async () => {
+      // Arrange
+      const deletedBy = 'admin-user';
+      let emittedEvent: BotDeletedEvent | null = null;
+      
+      deletionManager.on('botDeleted', (event: BotDeletedEvent) => {
+        emittedEvent = event;
+      });
+
+      // Act
+      await deletionManager.deleteBot(mockBot, deletedBy);
+
+      // Assert
+      expect(disconnectStub.calledOnce).to.be.true;
+      expect(emittedEvent).to.not.be.null;
+      expect(emittedEvent!.botId).to.equal('test-bot-id');
+      expect(emittedEvent!.deletedBy).to.equal(deletedBy);
+      expect(emittedEvent!.timestamp).to.be.instanceOf(Date);
+    });
+
+    it('should delete bot without deletedBy parameter', async () => {
+      // Arrange
+      let emittedEvent: BotDeletedEvent | null = null;
+      
+      deletionManager.on('botDeleted', (event: BotDeletedEvent) => {
+        emittedEvent = event;
+      });
+
+      // Act
+      await deletionManager.deleteBot(mockBot);
+
+      // Assert
+      expect(disconnectStub.calledOnce).to.be.true;
+      expect(emittedEvent).to.not.be.null;
+      expect(emittedEvent!.botId).to.equal('test-bot-id');
+      expect(emittedEvent!.deletedBy).to.be.undefined;
+    });
+
+    it('should handle bot disconnect failure gracefully', async () => {
+      // Arrange
+      disconnectStub.throws(new Error('Disconnect failed'));
+
+      // Act & Assert
+      try {
+        await deletionManager.deleteBot(mockBot);
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('Bot deletion failed: Disconnect failed');
+      }
+    });
+
+    it('should emit botDeleted event with correct data', async () => {
+      // Arrange
+      const deletedBy = 'test-admin';
+      let emittedEvent: BotDeletedEvent | null = null;
+      
+      deletionManager.on('botDeleted', (event: BotDeletedEvent) => {
+        emittedEvent = event;
+      });
+
+      // Act
+      await deletionManager.deleteBot(mockBot, deletedBy);
+
+      // Assert
+      expect(emittedEvent).to.not.be.null;
+      expect(emittedEvent!.botId).to.equal('test-bot-id');
+      expect(emittedEvent!.deletedBy).to.equal(deletedBy);
+      expect(emittedEvent!.timestamp).to.be.instanceOf(Date);
+      
+      // タイムスタンプが現在時刻に近いことを確認（1秒以内）
+      const timeDiff = Math.abs(new Date().getTime() - emittedEvent!.timestamp.getTime());
+      expect(timeDiff).to.be.lessThan(1000);
+    });
+  });
+});

--- a/tests/unit/deletionManager.test.ts
+++ b/tests/unit/deletionManager.test.ts
@@ -10,6 +10,8 @@ describe('DeletionManager', () => {
   let disconnectStub: sinon.SinonStub;
   let getSummaryStub: sinon.SinonStub;
 
+  let gracefulStopStub: sinon.SinonStub;
+
   beforeEach(() => {
     deletionManager = new DeletionManager();
     mockBot = new Bot();
@@ -20,6 +22,13 @@ describe('DeletionManager', () => {
       id: 'test-bot-id',
       state: BotState.Idle
     });
+    // 1秒待ちを回避しつつ disconnect 呼び出しは維持
+    gracefulStopStub = sinon
+      .stub(DeletionManager as any, 'gracefulStop')
+      .callsFake(async (...args: unknown[]) => {
+        const bot = args[0] as Bot;
+        bot.disconnect();
+      });
   });
 
   afterEach(() => {


### PR DESCRIPTION
- DeletionManagerクラスを実装
- BotControllerのdeleteBot メソッドを管理者権限チェック付きで更新
- BotServiceのdeleteBot メソッドをDeletionManagerを使用するよう更新
- BotDeletedイベントの型定義を追加
- 単体テストを実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 管理者権限が必要なボットの物理削除APIを追加し、削除フローと削除イベント通知（削除者情報含む）を実装。
- ドキュメント
  - 削除APIの仕様（物理削除・管理者必須）と既知の警告事項を追記。
- テスト
  - コントローラの成功/権限エラー/未検出/内部エラーを網羅するテストを追加。
  - 削除フローの正常系・障害時のハンドリングとイベント発行を検証するユニットテストを追加。
- スタイル
  - 未使用変数に関するESLintルールを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->