### PR TITLE
issueに対して，再接続機能の設計を追加しました．

### DIFF
--- a/docs/03_design/api/openapi.yaml
+++ b/docs/03_design/api/openapi.yaml
@@ -32,6 +32,16 @@ components:
         id: { type: string, format: uuid, example: "d6a7f..." }
         state: { type: string, enum: [Idle, Moving, Mining, ToolSwap] }
       required: [id, state]
+    BotHealthDTO:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [connected, disconnected]
+        lastSeenAt:
+          type: string
+          format: date-time
+      required: [status, lastSeenAt]
     PluginSpec:
       type: object
       properties:
@@ -202,3 +212,36 @@ paths:
               required: [name]
       responses:
         '202': { description: Accepted }
+
+  /bots/{botId}/health:
+    get:
+      summary: Get bot health status  #US-002-3
+      operationId: getBotHealth
+      tags: [Bot]
+      parameters:
+        - name: botId
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Bot health information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BotHealthDTO'
+              examples:
+                connected:
+                  value: { status: connected, lastSeenAt: '2025-08-24T02:50:00Z' }
+                disconnected:
+                  value: { status: disconnected, lastSeenAt: '2025-08-24T02:45:30Z' }
+        '404':
+          description: Bot not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '503':
+          description: Bot not connected
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/docs/03_design/diagrams/class/botcore.puml
+++ b/docs/03_design/diagrams/class/botcore.puml
@@ -22,6 +22,16 @@ class Bot <<Entity>> {
   +...
 }
 
+class BotConnectionManager <<Service>> {
+  +connect()
+  +disconnect(reason)
+  +autoReconnect(maxRetry = 5)
+  +keepAlive(interval = 10)
+  +isConnected(): boolean
+  -retryCount: int
+  -lastPingAt: Timestamp
+}
+
 class Protocol <<Service>> {
   +connect()
   +send(packet)
@@ -112,6 +122,7 @@ class Coord <<ValueObject>> {
 '---------------------------
 Bot "1" o-- "1" Protocol
 Bot "1" o-- "1" PluginLoader
+Bot "1" o-- "1" BotConnectionManager : manages
 PluginLoader "1" *-- "0..*" Plugin
 Plugin "1" -- "1" Bot
 

--- a/docs/03_design/diagrams/sequence/reconnect_flow.puml
+++ b/docs/03_design/diagrams/sequence/reconnect_flow.puml
@@ -1,0 +1,36 @@
+@startuml
+title #US-002-3 Bot 自動再接続・Keep-Aliveフロー
+
+actor Server
+participant Bot
+participant BotConnectionManager as BCM
+
+== サーバ切断時の自動再接続 ==
+Server -> Bot: Disconnect (timeout/idle)
+activate Bot
+Bot -> BCM: onDisconnect(event)
+activate BCM
+BCM -> BCM: schedule autoReconnect(backoff=1s, retryCount=0)
+loop 最大5回まで
+  BCM -> Server: connect()
+  alt success
+    BCM -> Bot: emit 'reconnected'
+    break
+  else fail & retryCount < 5
+    BCM -> BCM: backoff *= 2, retryCount++
+  else fail & retryCount >= 5
+    BCM -> Bot: emit 'reconnectFailed'
+    break
+  end
+end
+deactivate BCM
+
+== Keep-Alive ==
+... 10秒ごとに ...
+BCM -> Server: sendPing()
+Server --> BCM: pong/ACK
+alt 応答なし
+  BCM -> BCM: onPingTimeout() → disconnect & autoReconnect
+end
+
+@enduml

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ app.get('/bots/:id', (req, res) => botController.getBot(req, res));
 app.delete('/bots/:id', (req, res) => botController.deleteBot(req, res));
 app.get('/bots', (req, res) => botController.getAllBots(req, res));
 app.post('/bots/:id/area', (req, res) => botController.setMiningArea(req, res));
+app.post('/bots/:id/start', (req, res) => botController.startMining(req, res));
 
 // サーバーの起動
 app.listen(port, () => {

--- a/src/models/bot.model.ts
+++ b/src/models/bot.model.ts
@@ -62,6 +62,19 @@ export default class Bot {
         };
       });
 
+      // End/error ハンドラを追加
+      this.client.on('end', () => {
+        // console.log(`Bot ${this.id} disconnected.`);
+        this.client = null;
+        this.miningEngine = null; // エンジンも破棄
+      });
+
+      this.client.on('error', (err) => {
+        // console.error(`Bot ${this.id} connection error:`, err);
+        this.client = null;
+        this.miningEngine = null;
+      });
+
     } catch (error) {
       // console.error('Failed to connect:', error);
       throw new Error('Failed to connect to Minecraft server');

--- a/src/models/bot.model.ts
+++ b/src/models/bot.model.ts
@@ -66,15 +66,22 @@ export default class Bot {
       this.client.on('end', () => {
         // console.log(`Bot ${this.id} disconnected.`);
         this.client = null;
-        this.miningEngine = null; // エンジンも破棄
+        // エンジン停止と破棄（タイマー等のクリーンアップ）
+        this.miningEngine?.stop?.();
+        this.miningEngine = null;
+        // 接続断時は作業状態を解除（再開時の 409 回避）
+        this.state = BotState.Idle;
       });
 
-      this.client.on('error', (err) => {
+      this.client.on('error', (_err) => {
         // console.error(`Bot ${this.id} connection error:`, err);
         this.client = null;
+        // エンジン停止と破棄（タイマー等のクリーンアップ）
+        this.miningEngine?.stop?.();
         this.miningEngine = null;
+        // エラー状態へ遷移（観測性のため Idle と区別）
+        this.state = BotState.Error;
       });
-
     } catch (error) {
       // console.error('Failed to connect:', error);
       throw new Error('Failed to connect to Minecraft server');


### PR DESCRIPTION
- docs/03_design/diagrams/class/botcore.puml
- docs/03_design/diagrams/sequence/reconnect_flow.puml
- docs/03_design/api/openapi.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - BotのヘルスチェックAPIを追加（GET /bots/{botId}/health）。接続状態と最終確認時刻を取得可能。
  - Bot起動エンドポイントを追加（POST /bots/:id/start）。
- バグ修正
  - 切断・エラー発生時に接続やマイニング処理を適切にクリーンアップし、状態をIdle/Errorへ遷移するよう改善。スタックした状態やリソースリークを防止。
- ドキュメント
  - ヘルスチェックAPIのスキーマとエラーレスポンス仕様をOpenAPIに追加。
  - Bot接続管理のクラス図と自動再接続・Keep-Aliveのシーケンス図を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->